### PR TITLE
Implement item system with registry and palette UI

### DIFF
--- a/entities/player.go
+++ b/entities/player.go
@@ -4,6 +4,7 @@ import (
 	"dungeoneer/collision"
 	"dungeoneer/constants"
 	"dungeoneer/images"
+	"dungeoneer/inventory"
 	"dungeoneer/levels"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
@@ -45,6 +46,8 @@ type Player struct {
 
 	Caster *spells.Caster
 
+	Inventory *inventory.Inventory
+
 	LastMoveDirX float64
 	LastMoveDirY float64
 }
@@ -73,6 +76,7 @@ func NewPlayer(ss *sprites.SpriteSheet) *Player {
 			Delay:       constants.GrappleDelay,
 		},
 		Caster:       spells.NewCaster(),
+		Inventory:    inventory.NewInventory(),
 		LastMoveDirX: -1,
 		LastMoveDirY: 0,
 	}

--- a/game/draw.game.go
+++ b/game/draw.game.go
@@ -4,6 +4,7 @@ import (
 	"dungeoneer/constants"
 	"dungeoneer/fov"
 	"dungeoneer/spells"
+	"dungeoneer/ui"
 	"fmt"
 	"image"
 	"image/color"
@@ -114,6 +115,7 @@ func (g *Game) drawPlaying(screen *ebiten.Image, cx, cy float64) {
 		fov.DebugDrawRays(screen, g.cachedRays, g.camX, g.camY, g.camScale, cx, cy, g.currentLevel.TileSize)
 	}
 	g.drawDashUI(screen)
+	ui.DrawItemPalette(screen)
 	//fov.DebugDrawWalls(screen, g.RaycastWalls, g.camX, g.camY, g.camScale, cx, cy, g.currentLevel.TileSize)
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -4,6 +4,7 @@ import (
 	"dungeoneer/constants"
 	"dungeoneer/entities"
 	"dungeoneer/fov"
+	"dungeoneer/items"
 	"dungeoneer/leveleditor"
 	"dungeoneer/levels"
 	"dungeoneer/pathing"
@@ -110,6 +111,10 @@ func NewGame() (*Game, error) {
 		if wss, err := sprites.LoadWallSpriteSheet(fl); err == nil {
 			leveleditor.RegisterWallSprites(wss)
 		}
+	}
+
+	if err := items.LoadDefaultItems(); err != nil {
+		return nil, err
 	}
 
 	g := &Game{

--- a/game/handlers.game.go
+++ b/game/handlers.game.go
@@ -5,6 +5,7 @@ import (
 	"dungeoneer/levels"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
+	"dungeoneer/ui"
 	"math"
 	"os"
 
@@ -321,6 +322,7 @@ func (g *Game) handleInputPlaying() {
 	g.handleHoverTile()
 	g.handleClicks()
 	g.handleLevelHotkeys()
+	ui.HandleItemPaletteInput(g.player)
 }
 
 func (g *Game) handlePlayerVelocity() {

--- a/images/embed.go
+++ b/images/embed.go
@@ -92,6 +92,12 @@ var (
 
 	//go:embed smoke.png
 	Smoke_png []byte
+
+	//go:embed item_subset.png
+	Item_subset_png []byte
+
+	//go:embed item_reversemap_rows_0_1_2.json
+	Item_reversemap_rows_0_1_2_json []byte
 )
 
 // LoadEmbeddedImage loads images available through embed system, can pass name reference instead of the path

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -1,0 +1,51 @@
+package inventory
+
+import "dungeoneer/items"
+
+const (
+	Width  = 5
+	Height = 4
+)
+
+// Inventory holds a fixed grid of item pointers.
+type Inventory struct {
+	Grid [][]*items.Item
+}
+
+// NewInventory creates an empty inventory.
+func NewInventory() *Inventory {
+	inv := &Inventory{Grid: make([][]*items.Item, Height)}
+	for i := range inv.Grid {
+		inv.Grid[i] = make([]*items.Item, Width)
+	}
+	return inv
+}
+
+// AddItem places an item into the first available slot or stacks when possible.
+func (inv *Inventory) AddItem(it *items.Item) {
+	// try stacking
+	for y := 0; y < Height; y++ {
+		for x := 0; x < Width; x++ {
+			slot := inv.Grid[y][x]
+			if slot != nil && slot.ID == it.ID && slot.Stackable && slot.Count < slot.MaxStack {
+				needed := slot.MaxStack - slot.Count
+				if it.Count <= needed {
+					slot.Count += it.Count
+					return
+				}
+				slot.Count = slot.MaxStack
+				it.Count -= needed
+			}
+		}
+	}
+	// place in empty slot
+	for y := 0; y < Height; y++ {
+		for x := 0; x < Width; x++ {
+			if inv.Grid[y][x] == nil {
+				inv.Grid[y][x] = it
+				return
+			}
+		}
+	}
+	// inventory full; drop item (ignored for now)
+}

--- a/items/load.go
+++ b/items/load.go
@@ -1,0 +1,59 @@
+package items
+
+import (
+	"dungeoneer/images"
+	"encoding/json"
+	"image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// sheetEntry represents a single icon entry in the reverse map JSON.
+type sheetEntry struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Pos  struct {
+		Row int `json:"row"`
+		Col int `json:"col"`
+	} `json:"position"`
+}
+
+// LoadItemSheet registers items from the provided sheet and mapping.
+func LoadItemSheet(img *ebiten.Image, entries []sheetEntry) {
+	for _, e := range entries {
+		x0 := e.Pos.Col * 32
+		y0 := e.Pos.Row * 32
+		sub := img.SubImage(image.Rect(x0, y0, x0+32, y0+32)).(*ebiten.Image)
+		scaled := ebiten.NewImage(64, 64)
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Scale(2, 2)
+		scaled.DrawImage(sub, op)
+
+		tmpl := &ItemTemplate{
+			ID:         e.ID,
+			Name:       e.Name,
+			Type:       ItemMisc,
+			Stackable:  false,
+			MaxStack:   1,
+			Usable:     false,
+			Equippable: false,
+			Stats:      map[string]int{},
+			Icon:       scaled,
+		}
+		RegisterItem(tmpl)
+	}
+}
+
+// LoadDefaultItems loads the bundled item sheet and mapping.
+func LoadDefaultItems() error {
+	img, err := images.LoadEmbeddedImage(images.Item_subset_png)
+	if err != nil {
+		return err
+	}
+	var entries []sheetEntry
+	if err := json.Unmarshal(images.Item_reversemap_rows_0_1_2_json, &entries); err != nil {
+		return err
+	}
+	LoadItemSheet(img, entries)
+	return nil
+}

--- a/items/registry.go
+++ b/items/registry.go
@@ -1,0 +1,18 @@
+package items
+
+// Registry holds all loaded item templates keyed by ID.
+var Registry = map[string]*ItemTemplate{}
+
+// RegisterItem adds a new template to the global registry.
+func RegisterItem(tmpl *ItemTemplate) {
+	Registry[tmpl.ID] = tmpl
+}
+
+// NewItem creates an item instance from a template ID.
+func NewItem(id string) *Item {
+	tmpl, ok := Registry[id]
+	if !ok {
+		panic("Invalid item ID: " + id)
+	}
+	return &Item{ItemTemplate: tmpl, Count: 1}
+}

--- a/items/types.go
+++ b/items/types.go
@@ -1,0 +1,54 @@
+package items
+
+import "github.com/hajimehoshi/ebiten/v2"
+
+// ItemType categorizes items for basic behavior.
+type ItemType string
+
+const (
+	ItemWeapon     ItemType = "Weapon"
+	ItemArmor      ItemType = "Armor"
+	ItemConsumable ItemType = "Consumable"
+	ItemKey        ItemType = "Key"
+	ItemQuest      ItemType = "Quest"
+	ItemMisc       ItemType = "Misc"
+)
+
+// ItemTemplate defines common data shared across item instances.
+type ItemTemplate struct {
+	ID          string
+	Name        string
+	Type        ItemType
+	Description string
+	Stackable   bool
+	MaxStack    int
+	Usable      bool
+	Equippable  bool
+	Stats       map[string]int
+	Icon        *ebiten.Image
+	OnUse       func(p interface{}) // Optional user data
+}
+
+// Item represents an inventory instance.
+type Item struct {
+	*ItemTemplate
+	Count int
+}
+
+// ItemSave is a minimal representation for serialization.
+type ItemSave struct {
+	ID    string
+	Count int
+}
+
+// ToSave converts an item instance to its save form.
+func (i *Item) ToSave() ItemSave {
+	return ItemSave{ID: i.ID, Count: i.Count}
+}
+
+// FromSave recreates an item from saved data.
+func FromSave(data ItemSave) *Item {
+	it := NewItem(data.ID)
+	it.Count = data.Count
+	return it
+}

--- a/ui/itempalette.go
+++ b/ui/itempalette.go
@@ -1,0 +1,129 @@
+package ui
+
+import (
+	"dungeoneer/entities"
+	"dungeoneer/items"
+	"image"
+	"sort"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+var (
+	paletteVisible bool
+	paletteRect    = image.Rect(100, 100, 540, 420)
+	paletteScroll  int
+	itemIDs        []string
+)
+
+const (
+	paletteColumns = 4
+	paletteRows    = 3
+	spriteSize     = 64
+	padding        = 5
+)
+
+func ensureIDs() {
+	if len(itemIDs) == len(items.Registry) {
+		return
+	}
+	itemIDs = itemIDs[:0]
+	for id := range items.Registry {
+		itemIDs = append(itemIDs, id)
+	}
+	sort.Strings(itemIDs)
+}
+
+// HandleItemPaletteInput updates palette state and handles clicks.
+func HandleItemPaletteInput(p *entities.Player) {
+	if inpututil.IsKeyJustPressed(ebiten.KeyI) {
+		paletteVisible = !paletteVisible
+	}
+	if !paletteVisible {
+		return
+	}
+
+	_, wheel := ebiten.Wheel()
+	if wheel != 0 {
+		paletteScroll -= int(wheel) * paletteColumns
+		if paletteScroll < 0 {
+			paletteScroll = 0
+		}
+	}
+
+	if !inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+		return
+	}
+
+	x, y := ebiten.CursorPosition()
+	if !pointInRect(x, y, paletteRect) {
+		paletteVisible = false
+		return
+	}
+
+	ox := x - paletteRect.Min.X - padding
+	oy := y - paletteRect.Min.Y - padding
+	col := ox / (spriteSize + padding)
+	row := oy / (spriteSize + padding)
+	if col < 0 || col >= paletteColumns || row < 0 || row >= paletteRows {
+		return
+	}
+
+	idx := paletteScroll + row*paletteColumns + col
+	ensureIDs()
+	if idx >= 0 && idx < len(itemIDs) {
+		id := itemIDs[idx]
+		if p != nil && p.Inventory != nil {
+			p.Inventory.AddItem(items.NewItem(id))
+		}
+	}
+}
+
+// DrawItemPalette renders the developer item palette.
+func DrawItemPalette(screen *ebiten.Image) {
+	if !paletteVisible {
+		return
+	}
+	ensureIDs()
+	DrawMenuOverlay(screen, DefaultOverlayColor)
+	vector.DrawFilledRect(screen, float32(paletteRect.Min.X), float32(paletteRect.Min.Y),
+		float32(paletteRect.Dx()), float32(paletteRect.Dy()), DefaultBackgroundColor, false)
+
+	startX := paletteRect.Min.X + padding
+	startY := paletteRect.Min.Y + padding
+	perPage := paletteColumns * paletteRows
+
+	for i := 0; i < perPage && i+paletteScroll < len(itemIDs); i++ {
+		id := itemIDs[i+paletteScroll]
+		itm := items.Registry[id]
+		col := i % paletteColumns
+		row := i / paletteColumns
+		x := startX + col*(spriteSize+padding)
+		y := startY + row*(spriteSize+padding)
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Translate(float64(x), float64(y))
+		screen.DrawImage(itm.Icon, op)
+	}
+
+	mx, my := ebiten.CursorPosition()
+	if pointInRect(mx, my, paletteRect) {
+		ox := mx - startX
+		oy := my - startY
+		col := ox / (spriteSize + padding)
+		row := oy / (spriteSize + padding)
+		if col >= 0 && col < paletteColumns && row >= 0 && row < paletteRows {
+			idx := paletteScroll + row*paletteColumns + col
+			if idx >= 0 && idx < len(itemIDs) {
+				name := items.Registry[itemIDs[idx]].Name
+				ebitenutil.DebugPrintAt(screen, name, paletteRect.Min.X, paletteRect.Max.Y-15)
+			}
+		}
+	}
+}
+
+func pointInRect(x, y int, r image.Rectangle) bool {
+	return x >= r.Min.X && x < r.Max.X && y >= r.Min.Y && y < r.Max.Y
+}


### PR DESCRIPTION
## Summary
- create item definitions and registry
- load item templates from embedded sprite sheet
- add basic inventory and integrate into player
- provide developer item palette UI to spawn items

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68802cf37e408329a43f490f4540e675