### PR TITLE
Add basic item effects and dev tools

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -70,3 +70,5 @@ const (
 const (
 	FireballHitRadius = 0.75
 )
+
+var DebugMode = true

--- a/game/draw.game.go
+++ b/game/draw.game.go
@@ -123,6 +123,9 @@ func (g *Game) drawPlaying(screen *ebiten.Image, cx, cy float64) {
 	}
 	g.drawDashUI(screen)
 	ui.DrawItemPalette(screen)
+	if g.DevMenu != nil {
+		g.DevMenu.Draw(screen)
+	}
 	//fov.DebugDrawWalls(screen, g.RaycastWalls, g.camX, g.camY, g.camScale, cx, cy, g.currentLevel.TileSize)
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -50,6 +50,8 @@ type Game struct {
 	DamageNumbers          []entities.DamageNumber
 	HealNumbers            []entities.DamageNumber
 
+	DevMenu *ui.DevMenu
+
 	ActiveSpells    []spells.Spell
 	fireballSprites [][]*ebiten.Image
 
@@ -140,6 +142,7 @@ func NewGame() (*Game, error) {
 		camSmooth:       0.1,
 		SpellDebug:      true,
 	}
+	g.DevMenu = ui.NewDevMenu(640, 480, g.player)
 	g.editor.OnLayerChange = g.editorLayerChanged
 	g.editor.OnStairPlaced = g.stairPlaced
 	g.spawnEntitiesFromLevel()
@@ -537,6 +540,10 @@ func (g *Game) updatePlaying() error {
 	}
 
 	g.updateSpells()
+
+	if g.DevMenu != nil {
+		g.DevMenu.Update()
+	}
 
 	// Debugging / editor / effects
 	g.DebugLevelEditor()

--- a/items/load.go
+++ b/items/load.go
@@ -39,6 +39,9 @@ func LoadItemSheet(img *ebiten.Image, entries []sheetEntry) {
 			Equippable: false,
 			Stats:      map[string]int{},
 			Icon:       scaled,
+			OnUse:      nil,
+			OnEquip:    nil,
+			OnUnequip:  nil,
 		}
 		RegisterItem(tmpl)
 	}

--- a/items/types.go
+++ b/items/types.go
@@ -26,7 +26,9 @@ type ItemTemplate struct {
 	Equippable  bool
 	Stats       map[string]int
 	Icon        *ebiten.Image
-	OnUse       func(p interface{}) // Optional user data
+	OnUse       func(p interface{})
+	OnEquip     func(p interface{})
+	OnUnequip   func(p interface{})
 }
 
 // Item represents an inventory instance.

--- a/ui/devmenu.go
+++ b/ui/devmenu.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"dungeoneer/constants"
+	"dungeoneer/entities"
+	"dungeoneer/items"
+	"image"
+	"sort"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+// DevMenu provides a simple debug UI for spawning items.
+type DevMenu struct {
+	menu    *Menu
+	itemIDs []string
+	player  *entities.Player
+}
+
+// NewDevMenu creates a new dev menu centered on the screen.
+func NewDevMenu(w, h int, p *entities.Player) *DevMenu {
+	dm := &DevMenu{player: p}
+	dm.refreshItemIDs()
+	rect := image.Rect(w/2-150, h/2-150, w/2+150, h/2+150)
+	dm.menu = NewMenu(rect, "Spawn Item", dm.buildOptions(), DefaultMenuStyles())
+	dm.menu.SetInstructions([]string{"F2 Toggle", "Enter Spawn"})
+	return dm
+}
+
+func (dm *DevMenu) refreshItemIDs() {
+	dm.itemIDs = dm.itemIDs[:0]
+	for id := range items.Registry {
+		dm.itemIDs = append(dm.itemIDs, id)
+	}
+	sort.Strings(dm.itemIDs)
+}
+
+func (dm *DevMenu) buildOptions() []MenuOption {
+	options := []MenuOption{}
+	max := 10
+	if len(dm.itemIDs) < max {
+		max = len(dm.itemIDs)
+	}
+	for i := 0; i < max; i++ {
+		id := dm.itemIDs[i]
+		name := items.Registry[id].Name
+		itemID := id
+		options = append(options, MenuOption{
+			Text: name,
+			Action: func() {
+				if dm.player != nil {
+					dm.player.Inventory.AddItem(items.NewItem(itemID))
+				}
+			},
+		})
+	}
+	options = append(options, MenuOption{Text: "Close", Action: func() { dm.menu.Hide() }})
+	return options
+}
+
+// Update handles input and menu logic.
+func (dm *DevMenu) Update() {
+	if !constants.DebugMode {
+		return
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyF2) {
+		dm.menu.ToggleVisibility()
+	}
+	if dm.menu.IsVisible() {
+		dm.menu.Update()
+	}
+}
+
+// Draw renders the dev menu.
+func (dm *DevMenu) Draw(screen *ebiten.Image) {
+	if !constants.DebugMode {
+		return
+	}
+	if dm.menu.IsVisible() {
+		dm.menu.Draw(screen)
+	}
+}


### PR DESCRIPTION
## Summary
- extend item templates with equip/use hooks
- load icons for items from bundled sprite sheet
- track Stats and Equipment on the player
- provide developer menu to spawn items in debug mode

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68804c1e246c8329b64c27d658dac378