### PR TITLE
Add basic item effects and dev tools

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -70,3 +70,5 @@ const (
 const (
 	FireballHitRadius = 0.75
 )
+
+var DebugMode = true

--- a/entities/player.go
+++ b/entities/player.go
@@ -5,6 +5,7 @@ import (
 	"dungeoneer/constants"
 	"dungeoneer/images"
 	"dungeoneer/inventory"
+	"dungeoneer/items"
 	"dungeoneer/levels"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
@@ -16,6 +17,24 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 )
+
+// BaseStats are the fundamental RPG attributes.
+type BaseStats struct {
+	Strength     int `json:"strength"`
+	Dexterity    int `json:"dexterity"`
+	Vitality     int `json:"vitality"`
+	Intelligence int `json:"intelligence"`
+	Luck         int `json:"luck"`
+}
+
+// StatModifiers represent temporary or equipment-derived stat bonuses.
+type StatModifiers struct {
+	StrengthMod     int `json:"strength_mod"`
+	DexterityMod    int `json:"dexterity_mod"`
+	VitalityMod     int `json:"vitality_mod"`
+	IntelligenceMod int `json:"intelligence_mod"`
+	LuckMod         int `json:"luck_mod"`
+}
 
 type Player struct {
 	TileX, TileY int
@@ -46,7 +65,14 @@ type Player struct {
 
 	Caster *spells.Caster
 
-	Inventory *inventory.Inventory
+	Inventory     *inventory.Inventory
+	Stats         BaseStats
+	TempModifiers StatModifiers
+	Equipment     map[string]*items.Item
+
+	Mana, MaxMana int
+
+	Name string
 
 	LastMoveDirX float64
 	LastMoveDirY float64
@@ -75,10 +101,22 @@ func NewPlayer(ss *sprites.SpriteSheet) *Player {
 			Speed:       constants.GrappleSpeed,
 			Delay:       constants.GrappleDelay,
 		},
-		Caster:       spells.NewCaster(),
-		Inventory:    inventory.NewInventory(),
-		LastMoveDirX: -1,
-		LastMoveDirY: 0,
+		Caster:    spells.NewCaster(),
+		Inventory: inventory.NewInventory(),
+		Stats: BaseStats{
+			Strength:     1,
+			Dexterity:    1,
+			Vitality:     1,
+			Intelligence: 1,
+			Luck:         1,
+		},
+		TempModifiers: StatModifiers{},
+		Equipment:     make(map[string]*items.Item),
+		Mana:          20,
+		MaxMana:       20,
+		Name:          "Hero",
+		LastMoveDirX:  -1,
+		LastMoveDirY:  0,
 	}
 
 	// Whenever InterpX/InterpY crosses into a new tile, update TileX/TileY
@@ -87,6 +125,7 @@ func NewPlayer(ss *sprites.SpriteSheet) *Player {
 		p.TileY = y
 	}
 
+	p.RecalculateStats()
 	return p
 }
 
@@ -168,6 +207,13 @@ func (p *Player) Update(level *levels.Level, dt float64) {
 	p.updateGrapple(level, dt)
 	if p.Caster != nil {
 		p.Caster.Update(dt)
+	}
+
+	// Passive mana regeneration
+	regen := 1 + (p.Stats.Intelligence / 5)
+	p.Mana += int(float64(regen) * dt)
+	if p.Mana > p.MaxMana {
+		p.Mana = p.MaxMana
 	}
 
 	// Track last movement direction
@@ -407,5 +453,77 @@ func (p *Player) TakeDamage(dmg int) {
 	if p.HP <= 0 {
 		p.HP = 0
 		p.IsDead = true
+	}
+}
+
+func (p *Player) Equip(slot string, it *items.Item) {
+	if p.Equipment == nil {
+		p.Equipment = make(map[string]*items.Item)
+	}
+	if old, ok := p.Equipment[slot]; ok && old != nil {
+		if old.OnUnequip != nil {
+			old.OnUnequip(p)
+		}
+	}
+	p.Equipment[slot] = it
+	if it != nil && it.OnEquip != nil {
+		it.OnEquip(p)
+	}
+}
+
+func (p *Player) Unequip(slot string) {
+	if old, ok := p.Equipment[slot]; ok && old != nil {
+		if old.OnUnequip != nil {
+			old.OnUnequip(p)
+		}
+	}
+	delete(p.Equipment, slot)
+}
+
+func (p *Player) UseItem(it *items.Item) {
+	if it == nil || !it.Usable || it.OnUse == nil {
+		return
+	}
+	it.OnUse(p)
+}
+
+// getEquipmentStatModifiers sums stat bonuses from equipped items.
+func (p *Player) getEquipmentStatModifiers() StatModifiers {
+	mod := StatModifiers{}
+	for _, it := range p.Equipment {
+		if it == nil {
+			continue
+		}
+		if v, ok := it.Stats["Strength"]; ok {
+			mod.StrengthMod += v
+		}
+		if v, ok := it.Stats["Dexterity"]; ok {
+			mod.DexterityMod += v
+		}
+		if v, ok := it.Stats["Vitality"]; ok {
+			mod.VitalityMod += v
+		}
+		if v, ok := it.Stats["Intelligence"]; ok {
+			mod.IntelligenceMod += v
+		}
+		if v, ok := it.Stats["Luck"]; ok {
+			mod.LuckMod += v
+		}
+	}
+	return mod
+}
+
+// RecalculateStats updates derived fields like MaxHP, Damage, and AttackRate.
+func (p *Player) RecalculateStats() {
+	equip := p.getEquipmentStatModifiers()
+	p.MaxHP = 100 + (p.Stats.Vitality+p.TempModifiers.VitalityMod+equip.VitalityMod)*5
+	p.MaxMana = 20 + (p.Stats.Intelligence+p.TempModifiers.IntelligenceMod+equip.IntelligenceMod)*5
+	p.Damage = 5 + (p.Stats.Strength+equip.StrengthMod)*2
+	p.AttackRate = 60 - (p.Stats.Dexterity+equip.DexterityMod)*2
+	if p.HP > p.MaxHP {
+		p.HP = p.MaxHP
+	}
+	if p.Mana > p.MaxMana {
+		p.Mana = p.MaxMana
 	}
 }

--- a/entities/player_io.go
+++ b/entities/player_io.go
@@ -1,0 +1,29 @@
+package entities
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// SavePlayerToFile saves the player state to a JSON file.
+func SavePlayerToFile(p *Player, path string) error {
+	data := p.ToSaveData()
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, encoded, 0644)
+}
+
+// LoadPlayerFromFile loads a player from a JSON file.
+func LoadPlayerFromFile(path string) (*Player, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var data PlayerSave
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, err
+	}
+	return LoadPlayer(data), nil
+}

--- a/entities/player_save.go
+++ b/entities/player_save.go
@@ -1,0 +1,51 @@
+package entities
+
+import (
+	"dungeoneer/inventory"
+	"dungeoneer/items"
+	"dungeoneer/movement"
+)
+
+// PlayerSave represents the serializable player state.
+type PlayerSave struct {
+	Name      string                    `json:"name"`
+	TileX     int                       `json:"tile_x"`
+	TileY     int                       `json:"tile_y"`
+	Stats     BaseStats                 `json:"stats"`
+	Inventory [][]items.ItemSave        `json:"inventory"`
+	Equipment map[string]items.ItemSave `json:"equipment"`
+	HP        int                       `json:"hp"`
+	Mana      int                       `json:"mana"`
+}
+
+// ToSaveData converts the player to a serializable form.
+func (p *Player) ToSaveData() PlayerSave {
+	return PlayerSave{
+		Name:      p.Name,
+		TileX:     p.TileX,
+		TileY:     p.TileY,
+		Stats:     p.Stats,
+		HP:        p.HP,
+		Mana:      p.Mana,
+		Inventory: p.Inventory.ToSaveData(),
+		Equipment: items.SerializeEquipment(p.Equipment),
+	}
+}
+
+// LoadPlayer reconstructs a Player from saved data.
+func LoadPlayer(data PlayerSave) *Player {
+	p := &Player{
+		TileX:          data.TileX,
+		TileY:          data.TileY,
+		Stats:          data.Stats,
+		TempModifiers:  StatModifiers{},
+		Inventory:      inventory.FromSaveData(data.Inventory),
+		Equipment:      items.DeserializeEquipment(data.Equipment),
+		HP:             data.HP,
+		Mana:           data.Mana,
+		Name:           data.Name,
+		MoveController: movement.NewMovementController(5),
+	}
+	p.RecalculateStats()
+	return p
+}

--- a/game/draw.game.go
+++ b/game/draw.game.go
@@ -35,6 +35,8 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if g.isPaused {
 		if g.LoadLevelMenu != nil && g.LoadLevelMenu.Menu.IsVisible() {
 			g.LoadLevelMenu.Draw(screen)
+		} else if g.LoadPlayerMenu != nil && g.LoadPlayerMenu.Menu.IsVisible() {
+			g.LoadPlayerMenu.Draw(screen)
 		} else {
 			g.PauseMenu.Draw(screen)
 			if g.SavePrompt != nil && g.SavePrompt.IsVisible() {
@@ -123,6 +125,9 @@ func (g *Game) drawPlaying(screen *ebiten.Image, cx, cy float64) {
 	}
 	g.drawDashUI(screen)
 	ui.DrawItemPalette(screen)
+	if g.DevMenu != nil {
+		g.DevMenu.Draw(screen)
+	}
 	//fov.DebugDrawWalls(screen, g.RaycastWalls, g.camX, g.camY, g.camScale, cx, cy, g.currentLevel.TileSize)
 }
 

--- a/game/game.go
+++ b/game/game.go
@@ -21,17 +21,18 @@ import (
 )
 
 type Game struct {
-	w, h          int
-	currentWorld  *levels.LayeredLevel
-	currentLevel  *levels.Level
-	State         GameState
-	Menu          *ui.MainMenu
-	PauseMenu     *ui.PauseMenu
-	LoadLevelMenu *ui.LoadLevelMenu
-	SaveLevelMenu *ui.SaveLevelMenu
-	SavePrompt    *ui.TextInputMenu
-	LinkPrompt    *ui.LayerPrompt
-	isPaused      bool
+	w, h           int
+	currentWorld   *levels.LayeredLevel
+	currentLevel   *levels.Level
+	State          GameState
+	Menu           *ui.MainMenu
+	PauseMenu      *ui.PauseMenu
+	LoadLevelMenu  *ui.LoadLevelMenu
+	LoadPlayerMenu *ui.LoadPlayerMenu
+	SaveLevelMenu  *ui.SaveLevelMenu
+	SavePrompt     *ui.TextInputMenu
+	LinkPrompt     *ui.LayerPrompt
+	isPaused       bool
 
 	camX, camY           float64
 	minCamScale          float64
@@ -49,6 +50,8 @@ type Game struct {
 	HitMarkers             []entities.HitMarker
 	DamageNumbers          []entities.DamageNumber
 	HealNumbers            []entities.DamageNumber
+
+	DevMenu *ui.DevMenu
 
 	ActiveSpells    []spells.Spell
 	fireballSprites [][]*ebiten.Image
@@ -140,6 +143,7 @@ func NewGame() (*Game, error) {
 		camSmooth:       0.1,
 		SpellDebug:      true,
 	}
+	g.DevMenu = ui.NewDevMenu(640, 480, g.player)
 	g.editor.OnLayerChange = g.editorLayerChanged
 	g.editor.OnStairPlaced = g.stairPlaced
 	g.spawnEntitiesFromLevel()
@@ -162,11 +166,54 @@ func NewGame() (*Game, error) {
 			g.PauseMenu.Show() // <-- resume the previous menu
 		},
 	)
+	g.LoadPlayerMenu = ui.NewLoadPlayerMenu(g.w, g.h,
+		func(ply *entities.Player) {
+			g.player = ply
+			g.isPaused = false
+		},
+		func() {
+			g.LoadPlayerMenu.Hide()
+			if g.PauseMenu != nil {
+				g.PauseMenu.Show()
+			}
+		},
+	)
 	// Pause Menu
 	pm := ui.NewPauseMenu(l.W, l.H, ui.PauseMenuCallbacks{
-		OnResume:    func() { g.resumeGame() },
-		OnExit:      func() { os.Exit(0) },
-		OnLoadLevel: func() { g.LoadLevelMenu.Show() },
+		OnResume:     func() { g.resumeGame() },
+		OnExit:       func() { os.Exit(0) },
+		OnLoadLevel:  func() { g.LoadLevelMenu.Show() },
+		OnLoadPlayer: func() { g.LoadPlayerMenu.Show() },
+		OnSavePlayer: func() {
+			menuRect := image.Rect(g.w/2-200, g.h/2-100, g.w/2+200, g.h/2+100)
+			g.SavePrompt = ui.NewTextInputMenu(
+				menuRect,
+				"Save Player",
+				"Enter filename (with .json):",
+				func(filename string) {
+					path := "players/" + filename
+					err := entities.SavePlayerToFile(g.player, path)
+					if err != nil {
+						fmt.Println("Error saving player:", err)
+					} else {
+						fmt.Println("Saved player to:", path)
+						g.SavePrompt = ui.NewTextInputMenu(
+							menuRect,
+							"Success",
+							"Saved player to: "+filename,
+							nil,
+							nil,
+						)
+						g.SavePrompt.Instructions = []string{"Press Esc to close"}
+						g.SavePrompt.Show()
+					}
+				},
+				func() {
+					fmt.Println("Canceled saving player.")
+				},
+			)
+			g.SavePrompt.Show()
+		},
 		OnSaveLevel: func() {
 			menuRect := image.Rect(g.w/2-200, g.h/2-100, g.w/2+200, g.h/2+100)
 			g.SavePrompt = ui.NewTextInputMenu(
@@ -445,6 +492,8 @@ func (g *Game) updatePlaying() error {
 			g.SavePrompt.Update()
 		} else if g.LoadLevelMenu != nil && g.LoadLevelMenu.Menu.IsVisible() {
 			g.LoadLevelMenu.Update()
+		} else if g.LoadPlayerMenu != nil && g.LoadPlayerMenu.Menu.IsVisible() {
+			g.LoadPlayerMenu.Update()
 		} else {
 			g.PauseMenu.Update()
 		}
@@ -538,6 +587,10 @@ func (g *Game) updatePlaying() error {
 
 	g.updateSpells()
 
+	if g.DevMenu != nil {
+		g.DevMenu.Update()
+	}
+
 	// Debugging / editor / effects
 	g.DebugLevelEditor()
 	g.handleHitMarkers()
@@ -579,6 +632,10 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 	if g.LoadLevelMenu != nil {
 		g.LoadLevelMenu.SetRect(newRect)
+	}
+
+	if g.LoadPlayerMenu != nil {
+		g.LoadPlayerMenu.SetRect(newRect)
 	}
 
 	if g.SaveLevelMenu != nil {

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -12,6 +12,34 @@ type Inventory struct {
 	Grid [][]*items.Item
 }
 
+// ToSaveData serializes the inventory grid into a 2D slice of ItemSave.
+func (inv *Inventory) ToSaveData() [][]items.ItemSave {
+	data := make([][]items.ItemSave, Height)
+	for y := 0; y < Height; y++ {
+		row := make([]items.ItemSave, Width)
+		for x := 0; x < Width; x++ {
+			if it := inv.Grid[y][x]; it != nil {
+				row[x] = it.ToSave()
+			}
+		}
+		data[y] = row
+	}
+	return data
+}
+
+// FromSaveData reconstructs an Inventory from saved data.
+func FromSaveData(data [][]items.ItemSave) *Inventory {
+	inv := NewInventory()
+	for y := 0; y < len(data) && y < Height; y++ {
+		for x := 0; x < len(data[y]) && x < Width; x++ {
+			if data[y][x].ID != "" {
+				inv.Grid[y][x] = items.FromSave(data[y][x])
+			}
+		}
+	}
+	return inv
+}
+
 // NewInventory creates an empty inventory.
 func NewInventory() *Inventory {
 	inv := &Inventory{Grid: make([][]*items.Item, Height)}

--- a/items/load.go
+++ b/items/load.go
@@ -39,6 +39,9 @@ func LoadItemSheet(img *ebiten.Image, entries []sheetEntry) {
 			Equippable: false,
 			Stats:      map[string]int{},
 			Icon:       scaled,
+			OnUse:      nil,
+			OnEquip:    nil,
+			OnUnequip:  nil,
 		}
 		RegisterItem(tmpl)
 	}

--- a/items/types.go
+++ b/items/types.go
@@ -26,7 +26,9 @@ type ItemTemplate struct {
 	Equippable  bool
 	Stats       map[string]int
 	Icon        *ebiten.Image
-	OnUse       func(p interface{}) // Optional user data
+	OnUse       func(p interface{})
+	OnEquip     func(p interface{})
+	OnUnequip   func(p interface{})
 }
 
 // Item represents an inventory instance.
@@ -51,4 +53,26 @@ func FromSave(data ItemSave) *Item {
 	it := NewItem(data.ID)
 	it.Count = data.Count
 	return it
+}
+
+// SerializeEquipment converts an equipment map into savable data.
+func SerializeEquipment(eq map[string]*Item) map[string]ItemSave {
+	res := make(map[string]ItemSave)
+	for slot, it := range eq {
+		if it != nil {
+			res[slot] = it.ToSave()
+		}
+	}
+	return res
+}
+
+// DeserializeEquipment reconstructs an equipment map from saved data.
+func DeserializeEquipment(data map[string]ItemSave) map[string]*Item {
+	eq := make(map[string]*Item)
+	for slot, sv := range data {
+		if sv.ID != "" {
+			eq[slot] = FromSave(sv)
+		}
+	}
+	return eq
 }

--- a/ui/devmenu.go
+++ b/ui/devmenu.go
@@ -1,0 +1,83 @@
+package ui
+
+import (
+	"dungeoneer/constants"
+	"dungeoneer/entities"
+	"dungeoneer/items"
+	"image"
+	"sort"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+// DevMenu provides a simple debug UI for spawning items.
+type DevMenu struct {
+	menu    *Menu
+	itemIDs []string
+	player  *entities.Player
+}
+
+// NewDevMenu creates a new dev menu centered on the screen.
+func NewDevMenu(w, h int, p *entities.Player) *DevMenu {
+	dm := &DevMenu{player: p}
+	dm.refreshItemIDs()
+	rect := image.Rect(w/2-150, h/2-150, w/2+150, h/2+150)
+	dm.menu = NewMenu(rect, "Spawn Item", dm.buildOptions(), DefaultMenuStyles())
+	dm.menu.SetInstructions([]string{"F2 Toggle", "Enter Spawn"})
+	return dm
+}
+
+func (dm *DevMenu) refreshItemIDs() {
+	dm.itemIDs = dm.itemIDs[:0]
+	for id := range items.Registry {
+		dm.itemIDs = append(dm.itemIDs, id)
+	}
+	sort.Strings(dm.itemIDs)
+}
+
+func (dm *DevMenu) buildOptions() []MenuOption {
+	options := []MenuOption{}
+	max := 10
+	if len(dm.itemIDs) < max {
+		max = len(dm.itemIDs)
+	}
+	for i := 0; i < max; i++ {
+		id := dm.itemIDs[i]
+		name := items.Registry[id].Name
+		itemID := id
+		options = append(options, MenuOption{
+			Text: name,
+			Action: func() {
+				if dm.player != nil {
+					dm.player.Inventory.AddItem(items.NewItem(itemID))
+				}
+			},
+		})
+	}
+	options = append(options, MenuOption{Text: "Close", Action: func() { dm.menu.Hide() }})
+	return options
+}
+
+// Update handles input and menu logic.
+func (dm *DevMenu) Update() {
+	if !constants.DebugMode {
+		return
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyF2) {
+		dm.menu.ToggleVisibility()
+	}
+	if dm.menu.IsVisible() {
+		dm.menu.Update()
+	}
+}
+
+// Draw renders the dev menu.
+func (dm *DevMenu) Draw(screen *ebiten.Image) {
+	if !constants.DebugMode {
+		return
+	}
+	if dm.menu.IsVisible() {
+		dm.menu.Draw(screen)
+	}
+}

--- a/ui/load_player_menu.go
+++ b/ui/load_player_menu.go
@@ -1,0 +1,90 @@
+package ui
+
+import (
+	"dungeoneer/entities"
+	"fmt"
+	"image"
+	"os"
+	"path/filepath"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// LoadPlayerMenu allows selecting a saved player profile to load.
+type LoadPlayerMenu struct {
+	Menu         *Menu
+	OnPlayerLoad func(*entities.Player)
+	OnCancel     func()
+}
+
+func NewLoadPlayerMenu(w, h int, onLoad func(*entities.Player), onCancel func()) *LoadPlayerMenu {
+	style := DefaultMenuStyles()
+	menuWidth := 400
+	menuHeight := 400
+	menuX := (w - menuWidth) / 2
+	menuY := (h - menuHeight) / 2
+	rect := image.Rect(menuX, menuY, menuX+menuWidth, menuY+menuHeight)
+
+	menu := NewMenu(rect, "LOAD PLAYER", nil, style)
+	menu.SetInstructions([]string{"W/S/Arrows Navigate", "Enter/Space Select", "Esc to cancel"})
+
+	lpm := &LoadPlayerMenu{
+		Menu:         menu,
+		OnPlayerLoad: onLoad,
+		OnCancel:     onCancel,
+	}
+	lpm.populateMenuOptions()
+	return lpm
+}
+
+func (lpm *LoadPlayerMenu) populateMenuOptions() {
+	files, err := listSavedProfiles("players")
+	if err != nil {
+		lpm.Menu.options = []MenuOption{
+			{Text: "Error: " + err.Error(), Action: func() {}},
+			{Text: "Back", Action: lpm.OnCancel},
+		}
+		return
+	}
+	var options []MenuOption
+	for _, file := range files {
+		filename := file
+		options = append(options, MenuOption{
+			Text: filename,
+			Action: func() {
+				player, err := entities.LoadPlayerFromFile(filepath.Join("players", filename))
+				if err != nil {
+					fmt.Println("Failed to load player:", err)
+					return
+				}
+				if lpm.OnPlayerLoad != nil {
+					lpm.OnPlayerLoad(player)
+				}
+				lpm.Menu.Hide()
+			},
+		})
+	}
+	options = append(options, MenuOption{Text: "Back", Action: lpm.OnCancel})
+	lpm.Menu.options = options
+	lpm.Menu.SetSelectedIndex(0)
+}
+
+func (lpm *LoadPlayerMenu) Show()                     { lpm.populateMenuOptions(); lpm.Menu.Show() }
+func (lpm *LoadPlayerMenu) Hide()                     { lpm.Menu.Hide() }
+func (lpm *LoadPlayerMenu) Update()                   { lpm.Menu.Update() }
+func (lpm *LoadPlayerMenu) Draw(screen *ebiten.Image) { lpm.Menu.Draw(screen) }
+func (lpm *LoadPlayerMenu) SetRect(r image.Rectangle) { lpm.Menu.rect = r }
+
+func listSavedProfiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
+			files = append(files, entry.Name())
+		}
+	}
+	return files, nil
+}

--- a/ui/pause_menu.menu.go
+++ b/ui/pause_menu.menu.go
@@ -17,6 +17,8 @@ type PauseMenu struct {
 type PauseMenuCallbacks struct {
 	OnResume           func()
 	OnLoadLevel        func()
+	OnLoadPlayer       func()
+	OnSavePlayer       func()
 	OnSaveLevel        func()
 	OnNewBlank         func()
 	OnExit             func()
@@ -38,6 +40,8 @@ func NewPauseMenu(w, h int, cb PauseMenuCallbacks) *PauseMenu {
 	mainOptions := []MenuOption{
 		{Text: "Resume", Action: cb.OnResume},
 		{Text: "Load Level", Action: cb.OnLoadLevel},
+		{Text: "Load Player", Action: cb.OnLoadPlayer},
+		{Text: "Save Player", Action: cb.OnSavePlayer},
 		{Text: "Save Level", Action: cb.OnSaveLevel},
 		{Text: "New Blank Level", Action: cb.OnNewBlank},
 		{Text: "Settings", Action: func() {


### PR DESCRIPTION
## Summary
- extend item templates with equip/use hooks
- load icons for items from bundled sprite sheet
- track Stats and Equipment on the player
- provide developer menu to spawn items in debug mode
- add RPG stat system and player save/load support
- add menu to load player profiles during pause
- add pause menu option to save the current player

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68804c1e246c8329b64c27d658dac378