### PR TITLE
Fix escape key menu handling

### DIFF
--- a/game/handlers.game.go
+++ b/game/handlers.game.go
@@ -3,6 +3,7 @@ package game
 import (
 	"dungeoneer/entities"
 	"dungeoneer/levels"
+	"dungeoneer/menumanager"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
 	"dungeoneer/ui"
@@ -59,27 +60,24 @@ func (g *Game) handleMainMenuInput() {
 
 func (g *Game) handlePause() {
 	if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
-		if g.isPaused {
-			// Only resume if on main pause menu
-			if !g.PauseMenu.ShowSettings {
-				g.resumeGame()
-			} else {
-				// go back to main pause menu instead
-				g.PauseMenu.SwitchToMain()
-			}
-		} else {
-			g.isPaused = true
-			g.PauseMenu.Show()
+		// Close editor palettes first
+		if g.editor.PaletteOpen {
+			g.editor.TogglePalette()
+			return
 		}
+		if g.editor.EntityPaletteOpen {
+			g.editor.ToggleEntityPalette()
+			return
+		}
+
+		menumanager.Manager().HandleEscapePress()
 	}
+	g.isPaused = menumanager.Manager().Active == g.PauseMenu
 }
 
 func (g *Game) resumeGame() {
+	menumanager.Manager().CloseActiveMenu()
 	g.isPaused = false
-	if g.PauseMenu != nil { // Ensure pauseMenu exists
-		g.PauseMenu.MainMenu.Hide()
-		g.PauseMenu.SettingsMenu.Hide()
-	}
 }
 
 func (g *Game) handleZoom() {

--- a/menumanager/manager.go
+++ b/menumanager/manager.go
@@ -1,0 +1,66 @@
+package menumanager
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+)
+
+type Menu interface {
+	Show()
+	Hide()
+	IsVisible() bool
+}
+
+type MenuManager struct {
+	Active    Menu
+	PauseMenu Menu
+}
+
+var defaultManager *MenuManager
+
+func Init(pause Menu) {
+	defaultManager = &MenuManager{PauseMenu: pause}
+}
+
+func Manager() *MenuManager {
+	if defaultManager == nil {
+		defaultManager = &MenuManager{}
+	}
+	return defaultManager
+}
+
+func (mm *MenuManager) Open(menu Menu) {
+	if mm.Active != nil && mm.Active != menu {
+		mm.Active.Hide()
+	}
+	mm.Active = menu
+	if menu != nil {
+		menu.Show()
+	}
+}
+
+func (mm *MenuManager) CloseActiveMenu() {
+	if mm.Active != nil {
+		mm.Active.Hide()
+		mm.Active = nil
+	}
+}
+
+func (mm *MenuManager) HandleEscapePress() {
+	if !inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+		return
+	}
+	if mm.Active != nil {
+		if mm.Active == mm.PauseMenu {
+			mm.CloseActiveMenu()
+		} else {
+			mm.CloseActiveMenu()
+		}
+	} else if mm.PauseMenu != nil {
+		mm.Open(mm.PauseMenu)
+	}
+}
+
+func (mm *MenuManager) IsMenuOpen() bool {
+	return mm.Active != nil && mm.Active.IsVisible()
+}

--- a/ui/load_level_menu.go
+++ b/ui/load_level_menu.go
@@ -85,6 +85,8 @@ func (llm *LoadLevelMenu) Hide() {
 	llm.Menu.Hide()
 }
 
+func (llm *LoadLevelMenu) IsVisible() bool { return llm.Menu.IsVisible() }
+
 func (llm *LoadLevelMenu) Update() {
 	llm.Menu.Update()
 }

--- a/ui/load_player_menu.go
+++ b/ui/load_player_menu.go
@@ -71,6 +71,7 @@ func (lpm *LoadPlayerMenu) populateMenuOptions() {
 
 func (lpm *LoadPlayerMenu) Show()                     { lpm.populateMenuOptions(); lpm.Menu.Show() }
 func (lpm *LoadPlayerMenu) Hide()                     { lpm.Menu.Hide() }
+func (lpm *LoadPlayerMenu) IsVisible() bool           { return lpm.Menu.IsVisible() }
 func (lpm *LoadPlayerMenu) Update()                   { lpm.Menu.Update() }
 func (lpm *LoadPlayerMenu) Draw(screen *ebiten.Image) { lpm.Menu.Draw(screen) }
 func (lpm *LoadPlayerMenu) SetRect(r image.Rectangle) { lpm.Menu.rect = r }

--- a/ui/pause_menu.menu.go
+++ b/ui/pause_menu.menu.go
@@ -116,3 +116,13 @@ func (pm *PauseMenu) SwitchToSettings() {
 	pm.SettingsMenu.SetSelectedIndex(0) // Reset selected menu option to 1st index
 	pm.MainMenu.Hide()
 }
+
+func (pm *PauseMenu) Hide() {
+	pm.MainMenu.Hide()
+	pm.SettingsMenu.Hide()
+	pm.ShowSettings = false
+}
+
+func (pm *PauseMenu) IsVisible() bool {
+	return pm.MainMenu.IsVisible() || pm.SettingsMenu.IsVisible()
+}

--- a/ui/save_level_menu.go
+++ b/ui/save_level_menu.go
@@ -56,6 +56,7 @@ func (sm *SaveLevelMenu) saveAs(filename string) func() {
 
 func (sm *SaveLevelMenu) Show()                     { sm.Menu.Show() }
 func (sm *SaveLevelMenu) Hide()                     { sm.Menu.Hide() }
+func (sm *SaveLevelMenu) IsVisible() bool           { return sm.Menu.IsVisible() }
 func (sm *SaveLevelMenu) Update()                   { sm.Menu.Update() }
 func (sm *SaveLevelMenu) Draw(screen *ebiten.Image) { sm.Menu.Draw(screen) }
 func (sm *SaveLevelMenu) SetRect(r image.Rectangle) { sm.Menu.SetRect(r) }


### PR DESCRIPTION
## Summary
- add a global MenuManager to control which UI menu is active
- implement Hide/IsVisible on `PauseMenu`
- ensure load/save menus expose IsVisible
- integrate MenuManager in game logic to close/open menus
- update Escape key logic to close palettes before toggling pause
- use MenuManager.HandleEscapePress in pause handler

## Testing
- `go test ./...`
- attempted `git pull origin main` but there is no `origin` remote

------
https://chatgpt.com/codex/tasks/task_e_6888295bab6483299f7b891079c70ccb