### PR TITLE
Add EXP progression and hero panel

### DIFF
--- a/entities/player.go
+++ b/entities/player.go
@@ -9,6 +9,7 @@ import (
 	"dungeoneer/levels"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
+	"dungeoneer/progression"
 	"dungeoneer/spells"
 	"dungeoneer/sprites"
 	"fmt"
@@ -72,6 +73,10 @@ type Player struct {
 
 	Mana, MaxMana int
 
+	Level           int
+	EXP             int
+	AttributePoints int
+
 	Name string
 
 	LastMoveDirX float64
@@ -110,13 +115,16 @@ func NewPlayer(ss *sprites.SpriteSheet) *Player {
 			Intelligence: 1,
 			Luck:         1,
 		},
-		TempModifiers: StatModifiers{},
-		Equipment:     make(map[string]*items.Item),
-		Mana:          20,
-		MaxMana:       20,
-		Name:          "Hero",
-		LastMoveDirX:  -1,
-		LastMoveDirY:  0,
+		TempModifiers:   StatModifiers{},
+		Equipment:       make(map[string]*items.Item),
+		Mana:            20,
+		MaxMana:         20,
+		Level:           1,
+		EXP:             0,
+		AttributePoints: 0,
+		Name:            "Hero",
+		LastMoveDirX:    -1,
+		LastMoveDirY:    0,
 	}
 
 	// Whenever InterpX/InterpY crosses into a new tile, update TileX/TileY
@@ -485,6 +493,16 @@ func (p *Player) UseItem(it *items.Item) {
 		return
 	}
 	it.OnUse(p)
+}
+
+// AddEXP grants experience to the player and handles leveling.
+func (p *Player) AddEXP(amount int) {
+	p.EXP += amount
+	for p.EXP >= progression.EXPToLevel(p.Level) {
+		p.EXP -= progression.EXPToLevel(p.Level)
+		p.Level++
+		p.AttributePoints += 3
+	}
 }
 
 // getEquipmentStatModifiers sums stat bonuses from equipped items.

--- a/entities/player_save.go
+++ b/entities/player_save.go
@@ -10,27 +10,33 @@ import (
 
 // PlayerSave represents the serializable player state.
 type PlayerSave struct {
-	Name      string                    `json:"name"`
-	TileX     int                       `json:"tile_x"`
-	TileY     int                       `json:"tile_y"`
-	Stats     BaseStats                 `json:"stats"`
-	Inventory [][]items.ItemSave        `json:"inventory"`
-	Equipment map[string]items.ItemSave `json:"equipment"`
-	HP        int                       `json:"hp"`
-	Mana      int                       `json:"mana"`
+	Name            string                    `json:"name"`
+	TileX           int                       `json:"tile_x"`
+	TileY           int                       `json:"tile_y"`
+	Stats           BaseStats                 `json:"stats"`
+	Inventory       [][]items.ItemSave        `json:"inventory"`
+	Equipment       map[string]items.ItemSave `json:"equipment"`
+	HP              int                       `json:"hp"`
+	Mana            int                       `json:"mana"`
+	Level           int                       `json:"level"`
+	EXP             int                       `json:"exp"`
+	AttributePoints int                       `json:"ap"`
 }
 
 // ToSaveData converts the player to a serializable form.
 func (p *Player) ToSaveData() PlayerSave {
 	return PlayerSave{
-		Name:      p.Name,
-		TileX:     p.TileX,
-		TileY:     p.TileY,
-		Stats:     p.Stats,
-		HP:        p.HP,
-		Mana:      p.Mana,
-		Inventory: p.Inventory.ToSaveData(),
-		Equipment: items.SerializeEquipment(p.Equipment),
+		Name:            p.Name,
+		TileX:           p.TileX,
+		TileY:           p.TileY,
+		Stats:           p.Stats,
+		HP:              p.HP,
+		Mana:            p.Mana,
+		Level:           p.Level,
+		EXP:             p.EXP,
+		AttributePoints: p.AttributePoints,
+		Inventory:       p.Inventory.ToSaveData(),
+		Equipment:       items.SerializeEquipment(p.Equipment),
 	}
 }
 
@@ -43,19 +49,22 @@ func LoadPlayer(data PlayerSave) *Player {
 	blackMage, _ := images.LoadEmbeddedImage(images.Black_Mage_Full_png)
 
 	p := &Player{
-		TileX:          data.TileX,
-		TileY:          data.TileY,
-		LeftFacing:     true,
-		Sprite:         blackMage,
-		Stats:          data.Stats,
-		TempModifiers:  StatModifiers{},
-		Inventory:      inventory.FromSaveData(data.Inventory),
-		Equipment:      items.DeserializeEquipment(data.Equipment),
-		HP:             data.HP,
-		Mana:           data.Mana,
-		Name:           data.Name,
-		MoveController: mc,
-		Caster:         spells.NewCaster(),
+		TileX:           data.TileX,
+		TileY:           data.TileY,
+		LeftFacing:      true,
+		Sprite:          blackMage,
+		Stats:           data.Stats,
+		TempModifiers:   StatModifiers{},
+		Inventory:       inventory.FromSaveData(data.Inventory),
+		Equipment:       items.DeserializeEquipment(data.Equipment),
+		HP:              data.HP,
+		Mana:            data.Mana,
+		Level:           data.Level,
+		EXP:             data.EXP,
+		AttributePoints: data.AttributePoints,
+		Name:            data.Name,
+		MoveController:  mc,
+		Caster:          spells.NewCaster(),
 	}
 
 	mc.OnStep = func(x, y int) {

--- a/game/draw.game.go
+++ b/game/draw.game.go
@@ -123,6 +123,9 @@ func (g *Game) drawPlaying(screen *ebiten.Image, cx, cy float64) {
 	if g.HUD != nil && g.ShowHUD {
 		g.HUD.Draw(screen, g.w, g.h)
 	}
+	if g.HeroPanel != nil {
+		g.HeroPanel.Draw(screen)
+	}
 	ui.DrawItemPalette(screen)
 	if g.DevMenu != nil {
 		g.DevMenu.Draw(screen)

--- a/game/game.go
+++ b/game/game.go
@@ -53,9 +53,10 @@ type Game struct {
 	DamageNumbers          []entities.DamageNumber
 	HealNumbers            []entities.DamageNumber
 
-	DevMenu *ui.DevMenu
-	HUD     *hud.HUD
-	ShowHUD bool
+	DevMenu   *ui.DevMenu
+	HUD       *hud.HUD
+	ShowHUD   bool
+	HeroPanel *ui.HeroPanel
 
 	ActiveSpells    []spells.Spell
 	fireballSprites [][]*ebiten.Image
@@ -270,6 +271,7 @@ func NewGame() (*Game, error) {
 
 	g.HUD = hud.New()
 	g.ShowHUD = true
+	g.HeroPanel = ui.NewHeroPanel(g.w, g.h, g.player)
 	tomeNames := []string{"Red Tome", "Teal Tome", "Blue Tome", "Verdant Tome", "Crypt Tome"}
 	for i, name := range tomeNames {
 		for _, tmpl := range items.Registry {
@@ -618,6 +620,9 @@ func (g *Game) updatePlaying() error {
 	if g.DevMenu != nil {
 		g.DevMenu.Update()
 	}
+	if g.HeroPanel != nil {
+		g.HeroPanel.Update()
+	}
 
 	// Debugging / editor / effects
 	g.DebugLevelEditor()
@@ -664,6 +669,10 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 	if g.LoadPlayerMenu != nil {
 		g.LoadPlayerMenu.SetRect(newRect)
+	}
+
+	if g.HeroPanel != nil {
+		g.HeroPanel.SetRect(image.Rect((g.w-220)/2, (g.h-220)/2, (g.w+220)/2, (g.h+220)/2))
 	}
 
 	if g.SaveLevelMenu != nil {

--- a/game/handlers.game.go
+++ b/game/handlers.game.go
@@ -315,6 +315,12 @@ func (g *Game) handleInputPlaying() {
 		return
 	}
 
+	if inpututil.IsKeyJustPressed(ebiten.KeyH) {
+		if g.HeroPanel != nil {
+			g.HeroPanel.Toggle()
+		}
+	}
+
 	g.handleZoom()
 	g.handlePan()
 	g.handleDash()

--- a/progression/exp.go
+++ b/progression/exp.go
@@ -1,0 +1,18 @@
+package progression
+
+// EXPToLevel returns the experience required to reach the given level.
+func EXPToLevel(level int) int {
+	return 100*level + 50*level*level
+}
+
+// CalculateEXPReward computes the amount of EXP granted for defeating an enemy
+// of a particular level relative to the player's level.
+func CalculateEXPReward(enemyLevel, playerLevel int) int {
+	base := 50
+	diff := enemyLevel - playerLevel
+	multiplier := 1.0 + 0.2*float64(diff)
+	if multiplier < 0.1 {
+		multiplier = 0.1
+	}
+	return int(float64(base+enemyLevel*10) * multiplier)
+}

--- a/ui/hero_panel.go
+++ b/ui/hero_panel.go
@@ -1,0 +1,122 @@
+package ui
+
+import (
+	"dungeoneer/entities"
+	"dungeoneer/progression"
+	"fmt"
+	"image"
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// HeroPanel displays player stats and allows spending attribute points.
+type HeroPanel struct {
+	rect      image.Rectangle
+	player    *entities.Player
+	visible   bool
+	plusRects map[string]image.Rectangle
+}
+
+// NewHeroPanel creates a centered hero panel.
+func NewHeroPanel(w, h int, p *entities.Player) *HeroPanel {
+	width := 220
+	height := 220
+	x := (w - width) / 2
+	y := (h - height) / 2
+	return &HeroPanel{
+		rect:      image.Rect(x, y, x+width, y+height),
+		player:    p,
+		plusRects: make(map[string]image.Rectangle),
+	}
+}
+
+func (h *HeroPanel) Show()                     { h.visible = true }
+func (h *HeroPanel) Hide()                     { h.visible = false }
+func (h *HeroPanel) Toggle()                   { h.visible = !h.visible }
+func (h *HeroPanel) IsVisible() bool           { return h.visible }
+func (h *HeroPanel) SetRect(r image.Rectangle) { h.rect = r }
+
+// Update handles button clicks when visible.
+func (h *HeroPanel) Update() {
+	if !h.visible || h.player == nil {
+		return
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+		h.Hide()
+		return
+	}
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) && h.player.AttributePoints > 0 {
+		mx, my := ebiten.CursorPosition()
+		p := image.Pt(mx, my)
+		for stat, r := range h.plusRects {
+			if p.In(r) {
+				switch stat {
+				case "Strength":
+					h.player.Stats.Strength++
+				case "Intelligence":
+					h.player.Stats.Intelligence++
+				case "Vitality":
+					h.player.Stats.Vitality++
+				case "Dexterity":
+					h.player.Stats.Dexterity++
+				}
+				h.player.AttributePoints--
+				h.player.RecalculateStats()
+				break
+			}
+		}
+	}
+}
+
+// Draw renders the panel to the screen.
+func (h *HeroPanel) Draw(screen *ebiten.Image) {
+	if !h.visible || h.player == nil {
+		return
+	}
+	style := DefaultMenuStyles()
+	DrawMenuOverlay(screen, DefaultOverlayColor)
+	DrawMenuWindow(screen, &style, float32(h.rect.Min.X), float32(h.rect.Min.Y), float32(h.rect.Dx()), float32(h.rect.Dy()))
+
+	x := h.rect.Min.X + 10
+	y := h.rect.Min.Y + 20
+	ebitenutil.DebugPrintAt(screen, h.player.Name, x, y)
+	y += 20
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Level: %d", h.player.Level), x, y)
+	y += 20
+	required := progression.EXPToLevel(h.player.Level)
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("EXP: %d/%d", h.player.EXP, required), x, y)
+	barW := h.rect.Dx() - 20
+	barH := 8
+	percent := float32(h.player.EXP) / float32(required)
+	vector.DrawFilledRect(screen, float32(x), float32(y+10), float32(barW)*percent, float32(barH), color.RGBA{200, 200, 40, 255}, false)
+	vector.StrokeRect(screen, float32(x), float32(y+10), float32(barW), float32(barH), 1, color.White, false)
+	y += 30
+
+	h.plusRects = map[string]image.Rectangle{}
+	stats := []struct {
+		Name  string
+		Value int
+	}{
+		{"Strength", h.player.Stats.Strength},
+		{"Intelligence", h.player.Stats.Intelligence},
+		{"Vitality", h.player.Stats.Vitality},
+		{"Dexterity", h.player.Stats.Dexterity},
+	}
+
+	for _, st := range stats {
+		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%s: %d", st.Name, st.Value), x, y)
+		if h.player.AttributePoints > 0 {
+			px := x + 110
+			py := y - 10
+			vector.StrokeRect(screen, float32(px), float32(py), 12, 12, 1, color.White, false)
+			ebitenutil.DebugPrintAt(screen, "+", px+3, py-2)
+			h.plusRects[st.Name] = image.Rect(px, py, px+12, py+12)
+		}
+		y += 20
+	}
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Unspent Points: %d", h.player.AttributePoints), x, y)
+}


### PR DESCRIPTION
## Summary
- implement EXP scaling and reward formulas
- extend Player with level and attribute points
- create hero panel UI for viewing and upgrading stats
- hook hero panel to `H` key and integrate with game update/draw

## Testing
- `go build ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ab3cb542483299b856456a549951c