### PR TITLE
Add EXP system and hero panel

### DIFF
--- a/entities/ambush.monster.go
+++ b/entities/ambush.monster.go
@@ -36,6 +36,7 @@ func CreateAmbushMonster(sprite *ebiten.Image, x, y int) *Monster {
 		Damage:           2,
 		AttackRate:       45,
 		Behavior:         NewAmbushBehavior(4),
+		Level:            1,
 	}
 }
 
@@ -56,6 +57,7 @@ func NewStatueMonster(ss *sprites.SpriteSheet) []*Monster {
 			Damage:           2,
 			AttackRate:       45,
 			Behavior:         NewAmbushBehavior(4), // Trigger when player is within 2 tiles
+			Level:            1,
 		},
 		/*
 			{

--- a/entities/monster.go
+++ b/entities/monster.go
@@ -53,6 +53,8 @@ type Monster struct {
 	FlashTick      int
 	FlashTicksLeft int // total ticks remaining for the flash effect
 
+	Level int
+
 	Caster *spells.Caster
 }
 
@@ -73,6 +75,7 @@ func NewMonster(ss *sprites.SpriteSheet) []*Monster {
 			AttackRate:       30,
 			IsDead:           false,
 			Caster:           spells.NewCaster(),
+			Level:            1,
 		},
 	}
 }
@@ -279,7 +282,7 @@ func (m *Monster) UpdateFlashStatus() {
 	}
 }
 
-func (m *Monster) TakeDamage(dmg int, markers *[]HitMarker, damageNumbers *[]DamageNumber) {
+func (m *Monster) TakeDamage(dmg int, markers *[]HitMarker, damageNumbers *[]DamageNumber) bool {
 	m.HP -= dmg
 	if m.HP <= 0 {
 		m.IsDead = true
@@ -303,5 +306,5 @@ func (m *Monster) TakeDamage(dmg int, markers *[]HitMarker, damageNumbers *[]Dam
 		Ticks:    0,
 		MaxTicks: 30,
 	})
-
+	return m.IsDead
 }

--- a/entities/player.go
+++ b/entities/player.go
@@ -9,6 +9,7 @@ import (
 	"dungeoneer/levels"
 	"dungeoneer/movement"
 	"dungeoneer/pathing"
+	"dungeoneer/progression"
 	"dungeoneer/spells"
 	"dungeoneer/sprites"
 	"fmt"
@@ -70,6 +71,10 @@ type Player struct {
 	TempModifiers StatModifiers
 	Equipment     map[string]*items.Item
 
+	Level         int
+	EXP           int
+	UnspentPoints int
+
 	Mana, MaxMana int
 
 	Name string
@@ -112,6 +117,9 @@ func NewPlayer(ss *sprites.SpriteSheet) *Player {
 		},
 		TempModifiers: StatModifiers{},
 		Equipment:     make(map[string]*items.Item),
+		Level:         1,
+		EXP:           0,
+		UnspentPoints: 0,
 		Mana:          20,
 		MaxMana:       20,
 		Name:          "Hero",
@@ -525,5 +533,15 @@ func (p *Player) RecalculateStats() {
 	}
 	if p.Mana > p.MaxMana {
 		p.Mana = p.MaxMana
+	}
+}
+
+// AddEXP grants experience and handles level ups.
+func (p *Player) AddEXP(amount int) {
+	p.EXP += amount
+	for p.EXP >= progression.EXPToLevel(p.Level) {
+		p.EXP -= progression.EXPToLevel(p.Level)
+		p.Level++
+		p.UnspentPoints += 3
 	}
 }

--- a/entities/player_save.go
+++ b/entities/player_save.go
@@ -18,6 +18,9 @@ type PlayerSave struct {
 	Equipment map[string]items.ItemSave `json:"equipment"`
 	HP        int                       `json:"hp"`
 	Mana      int                       `json:"mana"`
+	Level     int                       `json:"level"`
+	EXP       int                       `json:"exp"`
+	Points    int                       `json:"points"`
 }
 
 // ToSaveData converts the player to a serializable form.
@@ -29,6 +32,9 @@ func (p *Player) ToSaveData() PlayerSave {
 		Stats:     p.Stats,
 		HP:        p.HP,
 		Mana:      p.Mana,
+		Level:     p.Level,
+		EXP:       p.EXP,
+		Points:    p.UnspentPoints,
 		Inventory: p.Inventory.ToSaveData(),
 		Equipment: items.SerializeEquipment(p.Equipment),
 	}
@@ -53,6 +59,9 @@ func LoadPlayer(data PlayerSave) *Player {
 		Equipment:      items.DeserializeEquipment(data.Equipment),
 		HP:             data.HP,
 		Mana:           data.Mana,
+		Level:          data.Level,
+		EXP:            data.EXP,
+		UnspentPoints:  data.Points,
 		Name:           data.Name,
 		MoveController: mc,
 		Caster:         spells.NewCaster(),

--- a/entities/roaming.monster.go
+++ b/entities/roaming.monster.go
@@ -38,6 +38,7 @@ func NewRoamingMonster(ss *sprites.SpriteSheet) []*Monster {
 			Damage:           2,
 			AttackRate:       45,
 			Behavior:         NewRoamingWanderBehavior(4),
+			Level:            1,
 		},
 	}
 }

--- a/game/draw.game.go
+++ b/game/draw.game.go
@@ -123,6 +123,9 @@ func (g *Game) drawPlaying(screen *ebiten.Image, cx, cy float64) {
 	if g.HUD != nil && g.ShowHUD {
 		g.HUD.Draw(screen, g.w, g.h)
 	}
+	if g.HeroPanel != nil && g.HeroPanel.IsVisible() {
+		g.HeroPanel.Draw(screen)
+	}
 	ui.DrawItemPalette(screen)
 	if g.DevMenu != nil {
 		g.DevMenu.Draw(screen)

--- a/game/game.go
+++ b/game/game.go
@@ -10,6 +10,7 @@ import (
 	"dungeoneer/levels"
 	"dungeoneer/menumanager"
 	"dungeoneer/pathing"
+	"dungeoneer/progression"
 	"dungeoneer/spells"
 	"dungeoneer/sprites"
 	"dungeoneer/ui"
@@ -598,6 +599,8 @@ func (g *Game) updatePlaying() error {
 				}
 			}
 			g.HUD.DashCooldown = maxCD
+			g.HUD.ExpCurrent = g.player.EXP
+			g.HUD.ExpNeeded = progression.EXPToLevel(g.player.Level)
 		}
 		if g.HeroPanel != nil {
 			g.HeroPanel.Update()

--- a/game/game.go
+++ b/game/game.go
@@ -53,9 +53,10 @@ type Game struct {
 	DamageNumbers          []entities.DamageNumber
 	HealNumbers            []entities.DamageNumber
 
-	DevMenu *ui.DevMenu
-	HUD     *hud.HUD
-	ShowHUD bool
+	DevMenu   *ui.DevMenu
+	HUD       *hud.HUD
+	ShowHUD   bool
+	HeroPanel *ui.HeroPanel
 
 	ActiveSpells    []spells.Spell
 	fireballSprites [][]*ebiten.Image
@@ -270,6 +271,8 @@ func NewGame() (*Game, error) {
 
 	g.HUD = hud.New()
 	g.ShowHUD = true
+	panelRect := image.Rect(g.w/2-150, g.h/2-150, g.w/2+150, g.h/2+150)
+	g.HeroPanel = ui.NewHeroPanel(panelRect, g.player)
 	tomeNames := []string{"Red Tome", "Teal Tome", "Blue Tome", "Verdant Tome", "Crypt Tome"}
 	for i, name := range tomeNames {
 		for _, tmpl := range items.Registry {
@@ -596,6 +599,9 @@ func (g *Game) updatePlaying() error {
 			}
 			g.HUD.DashCooldown = maxCD
 		}
+		if g.HeroPanel != nil {
+			g.HeroPanel.Update()
+		}
 		// Check layer links
 		if g.layerSwitchCooldown <= 0 {
 			for _, link := range g.currentWorld.Stairwells {
@@ -668,6 +674,11 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (int, int) {
 
 	if g.SaveLevelMenu != nil {
 		g.SaveLevelMenu.SetRect(newRect)
+	}
+
+	if g.HeroPanel != nil {
+		panel := image.Rect(g.w/2-150, g.h/2-150, g.w/2+150, g.h/2+150)
+		g.HeroPanel.SetRect(panel)
 	}
 
 	if g.editor == nil {

--- a/game/handlers.game.go
+++ b/game/handlers.game.go
@@ -167,8 +167,11 @@ func (g *Game) handleClicks() {
 			if m.TileX == cx && m.TileY == cy &&
 				entities.IsAdjacentRanged(g.player.TileX, g.player.TileY, m.TileX, m.TileY, 2) &&
 				g.player.CanAttack() {
-				m.TakeDamage(g.player.Damage, &g.HitMarkers, &g.DamageNumbers)
+				died := m.TakeDamage(g.player.Damage, &g.HitMarkers, &g.DamageNumbers)
 				g.player.AttackTick = 0
+				if died {
+					g.awardEXP(m)
+				}
 			}
 		}
 	}
@@ -216,6 +219,11 @@ func (g *Game) handleLevelHotkeys() {
 	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyF10) {
 		g.ShowHUD = !g.ShowHUD
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyH) {
+		if g.HeroPanel != nil {
+			g.HeroPanel.Toggle()
+		}
 	}
 	if inpututil.IsKeyJustPressed(ebiten.Key1) {
 		if g.player != nil {

--- a/game/progression.game.go
+++ b/game/progression.game.go
@@ -1,0 +1,14 @@
+package game
+
+import (
+	"dungeoneer/entities"
+	"dungeoneer/progression"
+)
+
+func (g *Game) awardEXP(m *entities.Monster) {
+	if g.player == nil || m == nil {
+		return
+	}
+	exp := progression.CalculateEXPReward(m.Level, g.player.Level)
+	g.player.AddEXP(exp)
+}

--- a/game/spells.game.go
+++ b/game/spells.game.go
@@ -95,10 +95,12 @@ func (g *Game) applyFireballDamage(fb *spells.Fireball, cx, cy int) {
 		dy := int(math.Abs(float64(m.TileY - cy)))
 		if dx <= radius && dy <= radius {
 			if g.hasLineOfSight(cx, cy, m.TileX, m.TileY) {
-				m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers)
-			}
-		}
-	}
+                               if m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers) {
+                                       g.awardEXP(m)
+                               }
+                       }
+               }
+       }
 }
 
 func (g *Game) hasLineOfSight(x1, y1, x2, y2 int) bool {
@@ -139,10 +141,12 @@ func (g *Game) applyChaosRayDamage(cr *spells.ChaosRay) {
 			p1 := cr.Path[i]
 			p2 := cr.Path[i+1]
 			if pointSegmentDistance(px, py, p1.X, p1.Y, p2.X, p2.Y) <= radius {
-				m.TakeDamage(cr.Info.Damage, &g.HitMarkers, &g.DamageNumbers)
-				break
-			}
-		}
+                               if m.TakeDamage(cr.Info.Damage, &g.HitMarkers, &g.DamageNumbers) {
+                                       g.awardEXP(m)
+                               }
+                               break
+                       }
+               }
 	}
 }
 
@@ -185,9 +189,11 @@ func (g *Game) applyLightningDamage(l *spells.LightningStrike, cx, cy int) {
 		dy := int(math.Abs(float64(m.TileY - cy)))
 		if dx <= radius && dy <= radius {
 			if g.hasLineOfSight(cx, cy, m.TileX, m.TileY) {
-				m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers)
-			}
-		}
+                               if m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers) {
+                                       g.awardEXP(m)
+                               }
+                       }
+               }
 	}
 }
 
@@ -227,10 +233,12 @@ func (g *Game) applyFractalDamage(n *spells.FractalNode, cx, cy int) {
 		dy := int(math.Abs(float64(m.TileY - cy)))
 		if dx <= radius && dy <= radius {
 			if g.hasLineOfSight(cx, cy, m.TileX, m.TileY) {
-				m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers)
-			}
-		}
-	}
+                               if m.TakeDamage(dmg, &g.HitMarkers, &g.DamageNumbers) {
+                                       g.awardEXP(m)
+                               }
+                       }
+               }
+       }
 }
 
 func (g *Game) castFractalBloom(centerX, centerY float64, c *spells.Caster) {

--- a/hud/hud.go
+++ b/hud/hud.go
@@ -24,6 +24,8 @@ type HUD struct {
 	ManaPercent   float64
 	DashCharges   int
 	DashCooldown  float64
+	ExpCurrent    int
+	ExpNeeded     int
 	SkillSlots    [5]SkillSlot
 	ActiveSkill   int
 
@@ -117,6 +119,7 @@ func (h *HUD) drawSkillBar(screen *ebiten.Image, w, hgt int) {
 	}
 
 	h.drawDashCharges(screen, x, barW, y)
+	h.drawEXPBar(screen, x, barW, y)
 }
 
 func (h *HUD) drawDashCharges(screen *ebiten.Image, barX, barW, barY int) {
@@ -140,6 +143,18 @@ func (h *HUD) drawDashCharges(screen *ebiten.Image, barX, barW, barY int) {
 		tx := start + (size*total+pad*(total-1)-b.Dx())/2
 		text.Draw(screen, txt, basicfont.Face7x13, tx, y-4, color.White)
 	}
+}
+
+func (h *HUD) drawEXPBar(screen *ebiten.Image, barX, barW, barY int) {
+	if h.ExpNeeded <= 0 {
+		return
+	}
+	dashSize := 18
+	y := barY - dashSize - 6 - 10
+	barH := 8
+	filled := int(float64(h.ExpCurrent) / float64(h.ExpNeeded) * float64(barW))
+	vector.DrawFilledRect(screen, float32(barX), float32(y), float32(barW), float32(barH), color.RGBA{80, 80, 80, 255}, false)
+	vector.DrawFilledRect(screen, float32(barX), float32(y), float32(filled), float32(barH), color.RGBA{0, 200, 0, 255}, false)
 }
 
 func drawOrb(dst *ebiten.Image, x, y, size int, percent float64, clr color.Color, frame *ebiten.Image, buf *ebiten.Image) {

--- a/progression/exp.go
+++ b/progression/exp.go
@@ -1,0 +1,15 @@
+package progression
+
+func EXPToLevel(level int) int {
+	return 100*level + 50*level*level
+}
+
+func CalculateEXPReward(enemyLevel, playerLevel int) int {
+	base := 50
+	diff := enemyLevel - playerLevel
+	multiplier := 1.0 + 0.2*float64(diff)
+	if multiplier < 0.1 {
+		multiplier = 0.1
+	}
+	return int(float64(base+enemyLevel*10) * multiplier)
+}

--- a/ui/helper.go
+++ b/ui/helper.go
@@ -1,9 +1,16 @@
 package ui
 
-import "regexp"
+import (
+	"image"
+	"regexp"
+)
 
 var validFilename = regexp.MustCompile(`^[a-zA-Z0-9._-]+\.json$`)
 
 func isValidFilename(name string) bool {
 	return validFilename.MatchString(name)
+}
+
+func pointInRect(x, y int, r image.Rectangle) bool {
+	return x >= r.Min.X && x < r.Max.X && y >= r.Min.Y && y < r.Max.Y
 }

--- a/ui/heropanel.go
+++ b/ui/heropanel.go
@@ -5,12 +5,10 @@ import (
 	"dungeoneer/progression"
 	"fmt"
 	"image"
-	"image/color"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
-	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
 // HeroPanel displays player stats and allows spending attribute points.
@@ -117,14 +115,9 @@ func (hp *HeroPanel) Draw(screen *ebiten.Image) {
 	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Level: %d", hp.player.Level), x, infoY)
 	infoY += 15
 	expNeeded := progression.EXPToLevel(hp.player.Level)
-	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("EXP: %d/%d", hp.player.EXP, expNeeded), x, infoY)
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("EXP: %d / %d", hp.player.EXP, expNeeded), x, infoY)
 
-	barWidth := 150
-	filled := int(float64(hp.player.EXP) / float64(expNeeded) * float64(barWidth))
-	vector.DrawFilledRect(screen, float32(x), float32(infoY+5), float32(barWidth), 6, color.RGBA{80, 80, 80, 255}, false)
-	vector.DrawFilledRect(screen, float32(x), float32(infoY+5), float32(filled), 6, color.RGBA{180, 180, 40, 255}, false)
-
-	statY := infoY + 25
+	statY := infoY + 20
 	stats := []struct {
 		key  string
 		name string

--- a/ui/heropanel.go
+++ b/ui/heropanel.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
@@ -43,7 +44,7 @@ func (hp *HeroPanel) Update() {
 		return
 	}
 	mx, my := ebiten.CursorPosition()
-	if ebiten.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 		for attr, r := range hp.plus {
 			if pointInRect(mx, my, r) && hp.player.UnspentPoints > 0 {
 				switch attr {

--- a/ui/heropanel.go
+++ b/ui/heropanel.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"dungeoneer/entities"
+	"dungeoneer/progression"
+	"fmt"
+	"image"
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// HeroPanel displays player stats and allows spending attribute points.
+// It intentionally keeps layout simple for readability.
+type HeroPanel struct {
+	rect    image.Rectangle
+	visible bool
+	player  *entities.Player
+	plus    map[string]image.Rectangle
+	minus   map[string]image.Rectangle
+}
+
+// NewHeroPanel creates a hero panel.
+func NewHeroPanel(r image.Rectangle, p *entities.Player) *HeroPanel {
+	return &HeroPanel{
+		rect:   r,
+		player: p,
+		plus:   make(map[string]image.Rectangle),
+		minus:  make(map[string]image.Rectangle),
+	}
+}
+
+func (hp *HeroPanel) SetRect(r image.Rectangle) { hp.rect = r }
+func (hp *HeroPanel) Show()                     { hp.visible = true }
+func (hp *HeroPanel) Hide()                     { hp.visible = false }
+func (hp *HeroPanel) Toggle()                   { hp.visible = !hp.visible }
+func (hp *HeroPanel) IsVisible() bool           { return hp.visible }
+
+func (hp *HeroPanel) Update() {
+	if !hp.visible || hp.player == nil {
+		return
+	}
+	mx, my := ebiten.CursorPosition()
+	if ebiten.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+		for attr, r := range hp.plus {
+			if pointInRect(mx, my, r) && hp.player.UnspentPoints > 0 {
+				switch attr {
+				case "str":
+					hp.player.Stats.Strength++
+				case "int":
+					hp.player.Stats.Intelligence++
+				case "vit":
+					hp.player.Stats.Vitality++
+				case "dex":
+					hp.player.Stats.Dexterity++
+				}
+				hp.player.UnspentPoints--
+				hp.player.RecalculateStats()
+				return
+			}
+		}
+		for attr, r := range hp.minus {
+			if pointInRect(mx, my, r) {
+				switch attr {
+				case "str":
+					if hp.player.Stats.Strength > 1 {
+						hp.player.Stats.Strength--
+						hp.player.UnspentPoints++
+					}
+				case "int":
+					if hp.player.Stats.Intelligence > 1 {
+						hp.player.Stats.Intelligence--
+						hp.player.UnspentPoints++
+					}
+				case "vit":
+					if hp.player.Stats.Vitality > 1 {
+						hp.player.Stats.Vitality--
+						hp.player.UnspentPoints++
+					}
+				case "dex":
+					if hp.player.Stats.Dexterity > 1 {
+						hp.player.Stats.Dexterity--
+						hp.player.UnspentPoints++
+					}
+				}
+				hp.player.RecalculateStats()
+				return
+			}
+		}
+	}
+}
+
+func (hp *HeroPanel) Draw(screen *ebiten.Image) {
+	if !hp.visible || hp.player == nil {
+		return
+	}
+
+	DrawMenuOverlay(screen, DefaultOverlayColor)
+	style := DefaultMenuStyles()
+	DrawMenuWindow(screen, &style, float32(hp.rect.Min.X), float32(hp.rect.Min.Y), float32(hp.rect.Dx()), float32(hp.rect.Dy()))
+
+	x := hp.rect.Min.X + 20
+	y := hp.rect.Min.Y + 20
+
+	// portrait
+	if hp.player.Sprite != nil {
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Translate(float64(x), float64(y))
+		screen.DrawImage(hp.player.Sprite, op)
+	}
+	infoY := y + 70
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Name: %s", hp.player.Name), x, infoY)
+	infoY += 15
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Level: %d", hp.player.Level), x, infoY)
+	infoY += 15
+	expNeeded := progression.EXPToLevel(hp.player.Level)
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("EXP: %d/%d", hp.player.EXP, expNeeded), x, infoY)
+
+	barWidth := 150
+	filled := int(float64(hp.player.EXP) / float64(expNeeded) * float64(barWidth))
+	vector.DrawFilledRect(screen, float32(x), float32(infoY+5), float32(barWidth), 6, color.RGBA{80, 80, 80, 255}, false)
+	vector.DrawFilledRect(screen, float32(x), float32(infoY+5), float32(filled), 6, color.RGBA{180, 180, 40, 255}, false)
+
+	statY := infoY + 25
+	stats := []struct {
+		key  string
+		name string
+		val  int
+	}{
+		{"str", "Strength", hp.player.Stats.Strength},
+		{"int", "Intelligence", hp.player.Stats.Intelligence},
+		{"vit", "Vitality", hp.player.Stats.Vitality},
+		{"dex", "Dexterity", hp.player.Stats.Dexterity},
+	}
+	hp.plus = make(map[string]image.Rectangle)
+	hp.minus = make(map[string]image.Rectangle)
+	for i, s := range stats {
+		lineY := statY + i*20
+		ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%s: %d", s.name, s.val), x, lineY)
+		pr := image.Rect(x+120, lineY-10, x+135, lineY+5)
+		mr := image.Rect(x+138, lineY-10, x+153, lineY+5)
+		hp.plus[s.key] = pr
+		hp.minus[s.key] = mr
+		if hp.player.UnspentPoints > 0 {
+			ebitenutil.DebugPrintAt(screen, "[+]", pr.Min.X, pr.Min.Y)
+		}
+		if s.val > 1 {
+			ebitenutil.DebugPrintAt(screen, "[-]", mr.Min.X, mr.Min.Y)
+		}
+	}
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("Unspent Points: %d", hp.player.UnspentPoints), x, statY+len(stats)*20+10)
+}

--- a/ui/itempalette.go
+++ b/ui/itempalette.go
@@ -123,7 +123,3 @@ func DrawItemPalette(screen *ebiten.Image) {
 		}
 	}
 }
-
-func pointInRect(x, y int, r image.Rectangle) bool {
-	return x >= r.Min.X && x < r.Max.X && y >= r.Min.Y && y < r.Max.Y
-}


### PR DESCRIPTION
## Summary
- add EXP/level calculations in new `progression` package
- track level, EXP, and stat points on the player and save them
- allow monsters to give experience when killed
- provide a toggleable hero panel UI to spend points
- wire hero panel and EXP into the game loop

## Testing
- `go build ./...` *(fails: missing X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_688ac0fc36e08329a0d2ada0e201dc41