### PR TITLE
feat: enable world item drops and pickups

### DIFF
--- a/entities/inventory_ops.go
+++ b/entities/inventory_ops.go
@@ -59,43 +59,41 @@ func (p *Player) Unequip(slot string) bool {
 	return true
 }
 
-// DropEquipped removes the item from the given equipment slot without adding it to the inventory.
-func (p *Player) DropEquipped(slot string) bool {
+// DropEquipped removes the item from the given equipment slot and returns it.
+func (p *Player) DropEquipped(slot string) *items.Item {
 	if p.Equipment == nil {
-		return false
+		return nil
 	}
 	it := p.Equipment[slot]
 	if it == nil {
-		return false
+		return nil
 	}
 	if it.OnUnequip != nil {
 		it.OnUnequip(p)
 	}
 	p.Equipment[slot] = nil
 	p.RecalculateStats()
-	// TODO: hook to drop into world
-	return true
+	return it
 }
 
-// DropFromInventory removes count items from the specified grid cell.
-func (p *Player) DropFromInventory(gx, gy int, count int) bool {
+// DropFromInventory removes count items from the specified grid cell and returns them.
+func (p *Player) DropFromInventory(gx, gy int, count int) *items.Item {
 	if p.Inventory == nil {
-		return false
+		return nil
 	}
 	if gy < 0 || gy >= p.Inventory.Height || gx < 0 || gx >= p.Inventory.Width {
-		return false
+		return nil
 	}
 	it := p.Inventory.Grid[gy][gx]
 	if it == nil {
-		return false
+		return nil
 	}
 	if count <= 0 || count >= it.Count {
 		p.Inventory.Grid[gy][gx] = nil
-	} else {
-		it.Count -= count
+		return it
 	}
-	// TODO: hook to drop into world
-	return true
+	it.Count -= count
+	return &items.Item{ItemTemplate: it.ItemTemplate, Count: count}
 }
 
 // AddToInventory attempts to add an item to the player's inventory.

--- a/entities/itemdrop.go
+++ b/entities/itemdrop.go
@@ -1,0 +1,30 @@
+package entities
+
+import (
+	"dungeoneer/items"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// ItemDrop represents an item lying on a level tile.
+type ItemDrop struct {
+	TileX, TileY int
+	Item         items.Item
+}
+
+// Draw renders the item's icon at its tile position.
+func (d *ItemDrop) Draw(screen *ebiten.Image, tileSize int, camX, camY, camScale, cx, cy float64) {
+	if d == nil || d.Item.Icon == nil {
+		return
+	}
+	x, y := isoToScreenFloat(float64(d.TileX), float64(d.TileY), tileSize)
+	op := &ebiten.DrawImageOptions{}
+	op.GeoM.Translate(x, y)
+	op.GeoM.Translate(-camX, camY)
+	op.GeoM.Scale(camScale, camScale)
+	op.GeoM.Translate(cx, cy)
+	screen.DrawImage(d.Item.Icon, op)
+}
+
+// Update is a no-op placeholder for ItemDrop.
+func (d *ItemDrop) Update() {}

--- a/entities/itemdrop.go
+++ b/entities/itemdrop.go
@@ -23,7 +23,7 @@ func (d *ItemDrop) Draw(screen *ebiten.Image, tileSize int, camX, camY, camScale
 	h := float64(b.Dy())
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(0.5, 0.5)
-	op.GeoM.Translate(-w/4, -h/2)
+	op.GeoM.Translate(-w/4, -h/4)
 	op.GeoM.Translate(x, y)
 	op.GeoM.Translate(-camX, camY)
 	op.GeoM.Scale(camScale, camScale)

--- a/entities/itemdrop.go
+++ b/entities/itemdrop.go
@@ -21,9 +21,10 @@ func (d *ItemDrop) Draw(screen *ebiten.Image, tileSize int, camX, camY, camScale
 	b := d.Item.Icon.Bounds()
 	w := float64(b.Dx())
 	h := float64(b.Dy())
+	ts := float64(tileSize)
 	op := &ebiten.DrawImageOptions{}
 	op.GeoM.Scale(0.5, 0.5)
-	op.GeoM.Translate(-w/4, -h/4)
+	op.GeoM.Translate(ts/2-w/4, ts/4-h/4)
 	op.GeoM.Translate(x, y)
 	op.GeoM.Translate(-camX, camY)
 	op.GeoM.Scale(camScale, camScale)

--- a/entities/itemdrop.go
+++ b/entities/itemdrop.go
@@ -18,7 +18,12 @@ func (d *ItemDrop) Draw(screen *ebiten.Image, tileSize int, camX, camY, camScale
 		return
 	}
 	x, y := isoToScreenFloat(float64(d.TileX), float64(d.TileY), tileSize)
+	b := d.Item.Icon.Bounds()
+	w := float64(b.Dx())
+	h := float64(b.Dy())
 	op := &ebiten.DrawImageOptions{}
+	op.GeoM.Scale(0.5, 0.5)
+	op.GeoM.Translate(-w/4, -h/2)
 	op.GeoM.Translate(x, y)
 	op.GeoM.Translate(-camX, camY)
 	op.GeoM.Scale(camScale, camScale)

--- a/game/handlers.game.go
+++ b/game/handlers.game.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"dungeoneer/entities"
+	"dungeoneer/items"
 	"dungeoneer/levels"
 	"dungeoneer/menumanager"
 	"dungeoneer/movement"
@@ -323,7 +324,9 @@ func (g *Game) handleInputPlaying() {
 		return
 	}
 	if g.InventoryScreen != nil && g.InventoryScreen.Active {
-		g.InventoryScreen.Update(g.player, g.ShowHint)
+		g.InventoryScreen.Update(g.player, g.ShowHint, func(it *items.Item) {
+			g.spawnItemDrop(it, g.player.TileX, g.player.TileY)
+		})
 		return
 	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {

--- a/game/render_collect.game.go
+++ b/game/render_collect.game.go
@@ -84,9 +84,10 @@ func (g *Game) collectItemDropRenderables(scale, cx, cy float64) []Renderable {
 		b := d.Item.Icon.Bounds()
 		w := float64(b.Dx())
 		h := float64(b.Dy())
+		ts := float64(g.currentLevel.TileSize)
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Scale(0.5, 0.5)
-		op.GeoM.Translate(-w/4, -h/4)
+		op.GeoM.Translate(ts/2-w/4, ts/4-h/4)
 		op.GeoM.Translate(xi, yi)
 		op.GeoM.Translate(-g.camX, g.camY)
 		op.GeoM.Scale(scale, scale)

--- a/game/render_collect.game.go
+++ b/game/render_collect.game.go
@@ -86,7 +86,7 @@ func (g *Game) collectItemDropRenderables(scale, cx, cy float64) []Renderable {
 		h := float64(b.Dy())
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Scale(0.5, 0.5)
-		op.GeoM.Translate(-w/4, -h/2)
+		op.GeoM.Translate(-w/4, -h/4)
 		op.GeoM.Translate(xi, yi)
 		op.GeoM.Translate(-g.camX, g.camY)
 		op.GeoM.Scale(scale, scale)

--- a/game/render_collect.game.go
+++ b/game/render_collect.game.go
@@ -81,7 +81,16 @@ func (g *Game) collectItemDropRenderables(scale, cx, cy float64) []Renderable {
 			continue
 		}
 		xi, yi := g.cartesianToIso(float64(d.TileX), float64(d.TileY))
-		op := g.getDrawOp(xi, yi, scale, cx, cy)
+		b := d.Item.Icon.Bounds()
+		w := float64(b.Dx())
+		h := float64(b.Dy())
+		op := &ebiten.DrawImageOptions{}
+		op.GeoM.Scale(0.5, 0.5)
+		op.GeoM.Translate(-w/4, -h/2)
+		op.GeoM.Translate(xi, yi)
+		op.GeoM.Translate(-g.camX, g.camY)
+		op.GeoM.Scale(scale, scale)
+		op.GeoM.Translate(cx, cy)
 		if !inFOV && wasSeen {
 			op.ColorScale.Scale(0.4, 0.4, 0.4, 1.0)
 		}

--- a/inventory/inventory.go
+++ b/inventory/inventory.go
@@ -68,19 +68,8 @@ func New(w, h int) *Inventory {
 // It returns true if the entire item stack was added, false if inventory was full.
 func (inv *Inventory) AddItem(it *items.Item) bool {
 	// try stacking
-	for y := 0; y < inv.Height; y++ {
-		for x := 0; x < inv.Width; x++ {
-			slot := inv.Grid[y][x]
-			if slot != nil && slot.ID == it.ID && slot.Stackable && slot.Count < slot.MaxStack {
-				needed := slot.MaxStack - slot.Count
-				if it.Count <= needed {
-					slot.Count += it.Count
-					return true
-				}
-				slot.Count = slot.MaxStack
-				it.Count -= needed
-			}
-		}
+	if TryStack(inv, *it) {
+		return true
 	}
 	// place in empty slot
 	for y := 0; y < inv.Height; y++ {

--- a/levels/level.go
+++ b/levels/level.go
@@ -28,6 +28,21 @@ type Level struct {
 	Entities []PlacedEntity
 }
 
+// AddEntity appends an entity to the level.
+func (l *Level) AddEntity(e PlacedEntity) {
+	l.Entities = append(l.Entities, e)
+}
+
+// RemoveEntityAt removes entities matching the given tile, type, and optional ID.
+func (l *Level) RemoveEntityAt(x, y int, typ, id string) {
+	for i := len(l.Entities) - 1; i >= 0; i-- {
+		e := l.Entities[i]
+		if e.X == x && e.Y == y && e.Type == typ && (id == "" || e.SpriteID == id) {
+			l.Entities = append(l.Entities[:i], l.Entities[i+1:]...)
+		}
+	}
+}
+
 // Tile returns the tile at the provided coordinates, or nil.
 func (l *Level) Tile(x, y int) *tiles.Tile {
 	if x >= 0 && y >= 0 && x < l.W && y < l.H {

--- a/ui/inventory.go
+++ b/ui/inventory.go
@@ -81,7 +81,7 @@ func (s *InventoryScreen) Open() {
 func (s *InventoryScreen) Close() { s.Active = false }
 
 // Update handles mouse and keyboard input while the screen is open.
-func (s *InventoryScreen) Update(p *entities.Player, hint func(string)) {
+func (s *InventoryScreen) Update(p *entities.Player, hint func(string), drop func(*items.Item)) {
 	if !s.Active || p == nil || p.Inventory == nil {
 		return
 	}
@@ -144,10 +144,14 @@ func (s *InventoryScreen) Update(p *entities.Player, hint func(string)) {
 							}
 						}
 					case "Drop":
+						var it *items.Item
 						if s.menuSlot != "" {
-							p.DropEquipped(s.menuSlot)
+							it = p.DropEquipped(s.menuSlot)
 						} else {
-							p.DropFromInventory(s.menuTargetX, s.menuTargetY, 1)
+							it = p.DropFromInventory(s.menuTargetX, s.menuTargetY, 1)
+						}
+						if it != nil && drop != nil {
+							drop(it)
 						}
 					case "Destroy":
 						if s.menuSlot != "" {
@@ -182,6 +186,12 @@ func (s *InventoryScreen) Update(p *entities.Player, hint func(string)) {
 	s.HoverGridX, s.HoverGridY = -1, -1
 	if gx >= 0 && gy >= 0 && gx < p.Inventory.Width && gy < p.Inventory.Height {
 		s.HoverGridX, s.HoverGridY = gx, gy
+	}
+
+	if s.HoverGridX >= 0 && s.HoverGridY >= 0 && inpututil.IsKeyJustPressed(ebiten.KeyD) {
+		if it := p.DropFromInventory(s.HoverGridX, s.HoverGridY, 1); it != nil && drop != nil {
+			drop(it)
+		}
 	}
 
 	if s.Dragging {


### PR DESCRIPTION
## Summary
- introduce ItemDrop entity to represent items on tiles
- allow dropping inventory items into the world and auto-pickup on move
- ensure inventory stacking uses TryStack and track world items per level

## Testing
- `go build -v ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8d23e37083299ba57a7a33f395c6