### PR TITLE
Fix spell controller integration and HUD spell slots

### DIFF
--- a/items/types.go
+++ b/items/types.go
@@ -38,6 +38,45 @@ type Item struct {
 	Count int
 }
 
+// SpellLoadout represents an entity capable of synchronizing tome-granted spells
+// with an underlying spell controller. Player implements this to allow tome
+// equipment callbacks to rebuild the player's known/equipped spells without
+// creating package cycles.
+type SpellLoadout interface {
+	RebuildSpellLoadout()
+}
+
+// TomeSpellInfo describes the spell granted by a tome item template.
+type TomeSpellInfo struct {
+	SpellKey  string
+	SpellName string
+}
+
+// TomeSpells maps tome item names to the spells they grant.
+var TomeSpells = map[string]TomeSpellInfo{
+	"Red Tome":     {SpellKey: "fireball", SpellName: "Fireball"},
+	"Teal Tome":    {SpellKey: "lightning", SpellName: "Lightning"},
+	"Crypt Tome":   {SpellKey: "chaosray", SpellName: "Chaos Ray"},
+	"Blue Tome":    {SpellKey: "fractalbloom", SpellName: "Fractal Bloom"},
+	"Verdant Tome": {SpellKey: "fractalcanopy", SpellName: "Fractal Canopy"},
+}
+
+// SpellKeyForTome returns the registry key for the spell granted by the tome.
+func SpellKeyForTome(name string) string {
+	if info, ok := TomeSpells[name]; ok {
+		return info.SpellKey
+	}
+	return ""
+}
+
+// SpellNameForTome returns the display name of the spell granted by the tome.
+func SpellNameForTome(name string) string {
+	if info, ok := TomeSpells[name]; ok {
+		return info.SpellName
+	}
+	return ""
+}
+
 // ItemEffect describes a special effect an item grants.
 type ItemEffect struct {
 	Trigger      string

--- a/spells/chaosray.spells.go
+++ b/spells/chaosray.spells.go
@@ -17,15 +17,16 @@ type Point struct {
 
 // ChaosRay is an instant lightning-like beam.
 type ChaosRay struct {
-	Info     SpellInfo
-	Path     []Point
-	Duration float64
-	Age      float64
-	Finished bool
+	Info       SpellInfo
+	Path       []Point
+	Duration   float64
+	Age        float64
+	Finished   bool
+	HitIndices map[int]bool
 }
 
 func NewChaosRay(info SpellInfo, startX, startY, endX, endY float64) *ChaosRay {
-	cr := &ChaosRay{Info: info, Duration: 0.5}
+	cr := &ChaosRay{Info: info, Duration: 0.5, HitIndices: make(map[int]bool)}
 	cr.Path = generateJaggedLightningPath(startX, startY, endX, endY)
 	return cr
 }

--- a/spells/fireball.spells.go
+++ b/spells/fireball.spells.go
@@ -50,13 +50,14 @@ type Fireball struct {
 	// Radius defines the hitbox for proximity checks
 	Radius float64
 
-	dirIndex   int
-	frame      int
-	tick       int
-	Impact     bool
-	impactTick int
-	ImpactImg  *ebiten.Image
-	Finished   bool
+	dirIndex      int
+	frame         int
+	tick          int
+	Impact        bool
+	impactTick    int
+	ImpactImg     *ebiten.Image
+	Finished      bool
+	DamageApplied bool
 }
 
 func NewFireball(info SpellInfo, startX, startY, targetX, targetY float64, sprites [][]*ebiten.Image, impact *ebiten.Image) *Fireball {

--- a/spells/lightningstorm.spells.go
+++ b/spells/lightningstorm.spells.go
@@ -84,10 +84,11 @@ func (ls *LightningStorm) Update(level *levels.Level, dt float64) {
 			if ls.ImpactImg != nil {
 				strike := NewLightningStrike(
 					SpellInfo{
-						Name:     "lightning",
-						Level:    1,
-						Cooldown: 0.01,
-						Damage:   ls.Info.Damage,
+						Name:        "lightning",
+						DisplayName: "Lightning",
+						Level:       1,
+						Cooldown:    0.01,
+						Damage:      ls.Info.Damage,
 					},
 					float64(tile.X), float64(tile.Y), ls.ImpactImg,
 				)
@@ -130,8 +131,14 @@ func abs(x int) int {
 func (ls *LightningStorm) IsFinished() bool { return ls.Finished }
 
 // TakeSpawns returns any LightningStrikes created since the last call.
-func (ls *LightningStorm) TakeSpawns() []*LightningStrike {
-	out := ls.spawned
+func (ls *LightningStorm) TakeSpawns() []Spell {
+	if len(ls.spawned) == 0 {
+		return nil
+	}
+	out := make([]Spell, len(ls.spawned))
+	for i, s := range ls.spawned {
+		out[i] = s
+	}
 	ls.spawned = nil
 	return out
 }

--- a/spells/spell.go
+++ b/spells/spell.go
@@ -8,11 +8,12 @@ import (
 
 // SpellInfo holds data about a spell type.
 type SpellInfo struct {
-	Name     string
-	Level    int
-	Cooldown float64
-	Damage   int
-	Cost     int
+	Name        string
+	DisplayName string
+	Level       int
+	Cooldown    float64
+	Damage      int
+	Cost        int
 }
 
 type Spell interface {


### PR DESCRIPTION
## Summary
- apply spell effects via the controller resolver and adopt spawned spells while keeping cooldown state in sync
- hook tome equip/unequip to rebuild the player spell loadout and expose spell icons/cooldowns to the HUD
- update the HUD skill bar to source tome icons, show top-down cooldown overlays, and provide spell tooltips

## Testing
- go build ./... *(fails: missing X11/extensions/Xrandr.h in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d21859a483298938250bd9a145b1